### PR TITLE
feat: enable CI/CD

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
             ]
         }
     },
-    "dockerFile": "../Dockerfile",
-    "context": "../src",
+    "image": "ghcr.io/kevin-secrist/latex:latest",
     "workspaceMount": "source=${localWorkspaceFolder},target=/data,type=bind,consistency=cached",
     "workspaceFolder": "/data",
     "runArgs": [ ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
   release:
     name: Release
     needs: build-documents
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -100,9 +100,7 @@ jobs:
           name: ${{ needs.build-documents.outputs.version }}
           tag_name: ${{ needs.build-documents.outputs.version }}
           generate_release_notes: true
-          # make_latest: true
-          make_latest: false
-          draft: true
+          make_latest: true
           fail_on_unmatched_files: true
           files: |
             secrist-resume.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,8 @@ jobs:
     name: Build Documents
     container:
       image: ghcr.io/${{ github.repository_owner }}/latex:${{ needs.build-docker.outputs.tag }}
+      options: --user 1001
     steps:
-      - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       - name: Detect Version from Ref
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,8 @@ jobs:
         working-directory: ${{ github.workspace }}/src
         env:
           VERSION: ${{ steps.detect_version.outputs.version }}
+      - run: ls -sR
+      - run: ls -sR ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,16 +34,15 @@ jobs:
               echo "build_image=false" >> "$GITHUB_OUTPUT";
             fi;
           fi;
-          cat "$GITHUB_OUTPUT"
       - name: Login to GitHub Container Registry
-        if: steps.select_image.outputs.build_image == true
+        if: steps.select_image.outputs.build_image == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        if: steps.select_image.outputs.build_image == true
+        if: steps.select_image.outputs.build_image == 'true'
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
       version: ${{ steps.version.outputs.v-version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get next version
         uses: reecetech/version-increment@2024.10.1
         id: version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
         id: select_image
         shell: bash
         run: |
-          branch=${{ github.ref_name }}
-          status=$(git diff --exit-code origin/main -- Dockerfile > /dev/null && echo "unchanged" || echo "changed")
-          if [[ "$branch" = "main" ]]; then
+          ref=${{ github.ref_name }}
+          status=$(git diff --exit-code origin/main:Dockerfile Dockerfile > /dev/null && echo "unchanged" || echo "changed")
+          if [[ "$ref" = "main" ]]; then
             echo "build_image=true" >> "$GITHUB_OUTPUT";
             echo "tag=latest" >> "$GITHUB_OUTPUT";
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
         uses: reecetech/version-increment@2024.10.1
         id: version
         with:
-          use_api: true
           scheme: conventional_commits
           increment: patch
       - name: Build with container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           if-no-files-found: error
           name: output
           path: |
-            ./src/out/cv.log
+            ./src/out/*.log
             ./src/out/*.pdf
   release:
     name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
           [[ $GITHUB_REF == refs/tags/v* ]] && VERSION="${GITHUB_REF#refs/tags/}" || VERSION="${GITHUB_SHA::8}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Build with container
-        run: build.sh
+        run: ./build.sh
         working-directory: ${{ github.workspace }}/src
         env:
           VERSION: ${{ steps.detect_version.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,19 +62,22 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository_owner }}/latex:${{ needs.build-docker.outputs.tag }}
       options: --user 1001
+    outputs:
+      version: ${{ steps.version.outputs.v-version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Detect Version from Ref
-        shell: bash
-        id: detect_version
-        run: |
-          [[ $GITHUB_REF == refs/tags/v* ]] && VERSION="${GITHUB_REF#refs/tags/}" || VERSION="${GITHUB_SHA::8}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Get next version
+        uses: reecetech/version-increment@2024.10.1
+        id: version
+        with:
+          use_api: true
+          scheme: conventional_commits
+          increment: patch
       - name: Build with container
         run: ./build.sh
         working-directory: ./src
         env:
-          VERSION: ${{ steps.detect_version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.v-version }}
       - uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -92,17 +95,10 @@ jobs:
         with:
           name: output
           pattern: "*.pdf"
-      - name: Get next version
-        uses: reecetech/version-increment@2024.10.1
-        id: version
-        with:
-          use_api: true
-          scheme: conventional_commits
-          increment: patch
       - uses: softprops/action-gh-release@v2
         with:
-          name: ${{ steps.version.outputs.v-version }}
-          tag_name: ${{ steps.version.outputs.v-version }}
+          name: ${{ needs.build-documents.outputs.version }}
+          tag_name: ${{ needs.build-documents.outputs.version }}
           generate_release_notes: true
           # make_latest: true
           make_latest: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          name: output
           pattern: "*.pdf"
       - uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,90 @@
+on: [push, pull_request]
+
+permissions:
+  contents: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    name: Build Docker Image
+    outputs:
+      tag: ${{ steps.select_image.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Docker Image
+        id: select_image
+        shell: bash
+        run: |
+          branch=${{ github.ref_name }}
+          status=$(git diff --exit-code origin/main Dockerfile > /dev/null && echo "unchanged" || echo "changed")
+          if [[ "$branch" = "main" ]]; then
+            echo "build_image=true" >> "$GITHUB_OUTPUT";
+            echo "tag=latest" >> "$GITHUB_OUTPUT";
+          else
+            if [[ "$status" = "unchanged" ]]; then
+              echo "tag=$GITHUB_SHA" >> "$GITHUB_OUTPUT";
+              echo "build_image=true" >> "$GITHUB_OUTPUT";
+            else
+              echo "tag=latest" >> "$GITHUB_OUTPUT";
+              echo "build_image=false" >> "$GITHUB_OUTPUT";
+            fi;
+          fi;
+      - name: Login to GitHub Container Registry
+        if: steps.select_image.outputs.build_image == true
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        if: steps.select_image.outputs.build_image == true
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}
+
+  build-documents:
+    runs-on: ubuntu-latest
+    needs: build-docker
+    name: Build Documents
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/latex:${{ needs.build-docker.outputs.tag }}
+      volumes:
+        - .:/data
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect Version from Ref
+        shell: bash
+        id: detect_version
+        run: |
+          [[ $GITHUB_REF == refs/tags/v* ]] && VERSION="${GITHUB_REF#refs/tags/}" || VERSION="${GITHUB_SHA::8}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Build with container
+        run: build.sh
+        working-directory: /data/src
+        env:
+          VERSION: ${{ steps.detect_version.outputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          path: |
+            /data/src/out/cv.log
+            /data/src/out/*.pdf
+  release:
+    name: Release
+    needs: build-documents
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*.pdf"
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            secrist-resume.pdf
+            secrist-cv.pdf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/latex:${{ steps.select_image.outputs.tag }}
 
   build-documents:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,18 +72,16 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Build with container
         run: ./build.sh
-        working-directory: ${{ github.workspace }}/src
+        working-directory: ./src
         env:
           VERSION: ${{ steps.detect_version.outputs.version }}
-      - run: ls -sR
-      - run: ls -sR ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: output
           path: |
-            ${{ github.workspace }}/src/out/cv.log
-            ${{ github.workspace }}/src/out/*.pdf
+            ./src/out/cv.log
+            ./src/out/*.pdf
   release:
     name: Release
     needs: build-documents

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,8 @@ jobs:
           VERSION: ${{ steps.detect_version.outputs.version }}
       - uses: actions/upload-artifact@v4
         with:
+          if-no-files-found: error
+          name: output
           path: |
             ${{ github.workspace }}/src/out/cv.log
             ${{ github.workspace }}/src/out/*.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             echo "build_image=true" >> "$GITHUB_OUTPUT";
             echo "tag=latest" >> "$GITHUB_OUTPUT";
           else
-            if [[ "$status" = "unchanged" ]]; then
+            if [[ "$status" = "changed" ]]; then
               echo "tag=$GITHUB_SHA" >> "$GITHUB_OUTPUT";
               echo "build_image=true" >> "$GITHUB_OUTPUT";
             else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,14 @@ jobs:
       tag: ${{ steps.select_image.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Select Docker Image
         id: select_image
         shell: bash
         run: |
           ref=${{ github.ref_name }}
-          status=$(git diff --exit-code origin/main:Dockerfile Dockerfile > /dev/null && echo "unchanged" || echo "changed")
+          status=$(git diff --exit-code origin/main Dockerfile > /dev/null && echo "unchanged" || echo "changed")
           if [[ "$ref" = "main" ]]; then
             echo "build_image=true" >> "$GITHUB_OUTPUT";
             echo "tag=latest" >> "$GITHUB_OUTPUT";

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,17 +85,29 @@ jobs:
   release:
     name: Release
     needs: build-documents
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: output
           pattern: "*.pdf"
+      - name: Get next version
+        uses: reecetech/version-increment@2024.10.1
+        id: version
+        with:
+          use_api: true
+          scheme: conventional_commits
+          increment: patch
       - uses: softprops/action-gh-release@v2
         with:
+          name: ${{ steps.version.outputs.v-version }}
+          tag_name: ${{ steps.version.outputs.v-version }}
+          generate_release_notes: true
+          # make_latest: true
+          make_latest: false
+          draft: true
+          fail_on_unmatched_files: true
           files: |
             secrist-resume.pdf
             secrist-cv.pdf
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: main
 
 permissions:
   contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         if: steps.select_image.outputs.build_image == 'true'
         uses: docker/build-push-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash
         run: |
           branch=${{ github.ref_name }}
-          status=$(git diff --exit-code origin/main Dockerfile > /dev/null && echo "unchanged" || echo "changed")
+          status=$(git diff --exit-code origin/main -- Dockerfile > /dev/null && echo "unchanged" || echo "changed")
           if [[ "$branch" = "main" ]]; then
             echo "build_image=true" >> "$GITHUB_OUTPUT";
             echo "tag=latest" >> "$GITHUB_OUTPUT";

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,8 @@ jobs:
     name: Build Documents
     container:
       image: ghcr.io/${{ github.repository_owner }}/latex:${{ needs.build-docker.outputs.tag }}
-      volumes:
-        - .:/data
     steps:
+      - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       - name: Detect Version from Ref
         shell: bash
@@ -73,14 +72,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Build with container
         run: build.sh
-        working-directory: /data/src
+        working-directory: ${{ github.workspace }}/src
         env:
           VERSION: ${{ steps.detect_version.outputs.version }}
       - uses: actions/upload-artifact@v4
         with:
           path: |
-            /data/src/out/cv.log
-            /data/src/out/*.pdf
+            ${{ github.workspace }}/src/out/cv.log
+            ${{ github.workspace }}/src/out/*.pdf
   release:
     name: Release
     needs: build-documents

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,12 +66,11 @@ jobs:
       version: ${{ steps.version.outputs.v-version }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Get next version
         uses: reecetech/version-increment@2024.10.1
         id: version
         with:
+          use_api: true
           scheme: conventional_commits
           increment: patch
       - name: Build with container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
               echo "build_image=false" >> "$GITHUB_OUTPUT";
             fi;
           fi;
+          cat "$GITHUB_OUTPUT"
       - name: Login to GitHub Container Registry
         if: steps.select_image.outputs.build_image == true
         uses: docker/login-action@v3

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -13,6 +13,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -2,6 +2,9 @@ on:
   schedule:
     - cron: "0 16 * * 2"
 
+permissions:
+  packages: write
+
 jobs:
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,0 +1,23 @@
+on:
+  schedule:
+    - cron: "0 16 * * 2"
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    name: Build Docker Image
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/latex:latest
+            ghcr.io/${{ github.repository_owner }}/latex:latest

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -23,5 +23,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ github.repository_owner }}/latex:latest
             ghcr.io/${{ github.repository_owner }}/latex:latest

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ github.repository_owner }}/latex:latest
             ghcr.io/${{ github.repository_owner }}/latex:latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "latex-workshop.latex.outDir": "%DIR%/../out",
+    "latex-workshop.latex.outDir": "%DIR%/out",
     "latex-workshop.latex.recipes": [
         {
             "name": "latexmk",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:noble
 
 RUN apt-get update \
-&&  apt-get install -y build-essential wget curl libfontconfig1 tzdata \
+&&  apt-get install -y build-essential wget curl libfontconfig1 tzdata jq \
 &&  rm -rf /var/lib/apt/lists/*
 
 ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
+# the ubuntu image now creates a user "ubuntu" by default with UID 1000
+# the USERNAME will only be used if the given UID is not already taken
 ARG USERNAME=latex
 ARG UID=1000
 ARG GID=$UID
-RUN groupadd --gid $GID $USERNAME \
-&&  useradd --uid $UID --gid $GID -m $USERNAME
+RUN id -g $GID &>/dev/null || groupadd --gid $GID $USERNAME \
+&&  id -u $UID &>/dev/null || useradd --uid $UID --gid $GID -m $USERNAME
 
 ARG TZ
 ENV TZ="$TZ"
@@ -15,9 +17,9 @@ RUN apt-get update \
 &&  rm -rf /var/lib/apt/lists/*
 
 ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet
-ENV MANPATH "${MANPATH}:/usr/local/texlive/2023/texmf-dist/doc/man"
-ENV INFOPATH "${INFOPATH}:/usr/local/texlive/2023/texmf-dist/doc/info"
-ENV PATH "${PATH}:/usr/local/texlive/2023/bin/x86_64-linux"
+ENV MANPATH "${MANPATH}:/usr/local/texlive/2024/texmf-dist/doc/man"
+ENV INFOPATH "${INFOPATH}:/usr/local/texlive/2024/texmf-dist/doc/info"
+ENV PATH "${PATH}:/usr/local/texlive/2024/bin/x86_64-linux"
 
 RUN mkdir /install-tl-unx \
 &&  curl -sSL \
@@ -52,6 +54,4 @@ RUN tlmgr install --repository ${TEXLIVE_MIRROR} \
       tcolorbox \
       tikzfill
 
-USER $USERNAME
-WORKDIR /data/src
-VOLUME ["/data"]
+USER $UID:$GID

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,5 @@ RUN tlmgr install --repository ${TEXLIVE_MIRROR} \
       tikzfill
 
 USER $UID:$GID
+LABEL org.opencontainers.image.source=https://github.com/kevin-secrist/resume
+LABEL org.opencontainers.image.description="Basic LaTeX image for building a resume"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update \
 &&  rm -rf /var/lib/apt/lists/*
 
 ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet
-ENV MANPATH="${MANPATH}:/usr/local/texlive/2024/texmf-dist/doc/man" \
-    INFOPATH="${INFOPATH}:/usr/local/texlive/2024/texmf-dist/doc/info" \
+ENV MANPATH="/usr/local/texlive/2024/texmf-dist/doc/man" \
+    INFOPATH="/usr/local/texlive/2024/texmf-dist/doc/info" \
     PATH="${PATH}:/usr/local/texlive/2024/bin/x86_64-linux"
 
 RUN mkdir /install-tl-unx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,13 @@
 FROM ubuntu:noble
 
-# the ubuntu image now creates a user "ubuntu" by default with UID 1000
-# the USERNAME will only be used if the given UID is not already taken
-ARG USERNAME=latex
-ARG UID=1000
-ARG GID=$UID
-RUN id -g $GID &>/dev/null || groupadd --gid $GID $USERNAME \
-&&  id -u $UID &>/dev/null || useradd --uid $UID --gid $GID -m $USERNAME
-
-ARG TZ
-ENV TZ="$TZ"
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
 RUN apt-get update \
 &&  apt-get install -y build-essential wget curl libfontconfig1 tzdata \
 &&  rm -rf /var/lib/apt/lists/*
 
 ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet
-ENV MANPATH "${MANPATH}:/usr/local/texlive/2024/texmf-dist/doc/man"
-ENV INFOPATH "${INFOPATH}:/usr/local/texlive/2024/texmf-dist/doc/info"
-ENV PATH "${PATH}:/usr/local/texlive/2024/bin/x86_64-linux"
+ENV MANPATH="${MANPATH}:/usr/local/texlive/2024/texmf-dist/doc/man" \
+    INFOPATH="${INFOPATH}:/usr/local/texlive/2024/texmf-dist/doc/info" \
+    PATH="${PATH}:/usr/local/texlive/2024/bin/x86_64-linux"
 
 RUN mkdir /install-tl-unx \
 &&  curl -sSL \
@@ -54,6 +42,5 @@ RUN tlmgr install --repository ${TEXLIVE_MIRROR} \
       tcolorbox \
       tikzfill
 
-USER $UID:$GID
 LABEL org.opencontainers.image.source=https://github.com/kevin-secrist/resume
 LABEL org.opencontainers.image.description="Basic LaTeX image for building a resume"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:noble
 
 RUN apt-get update \
-&&  apt-get install -y build-essential wget curl libfontconfig1 tzdata jq \
+&&  apt-get install -y build-essential wget curl libfontconfig1 tzdata jq git \
 &&  rm -rf /var/lib/apt/lists/*
 
 ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you prefer to develop without VS Code, or without the containers extension, y
 
 ```bash
 docker build -t latex-build .
-docker run -v $PWD:/data latex-build /data/src/build.sh
+docker run -v $PWD:/data -w /data/src latex-build ./build.sh
 ```
 
 # Inspirations

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-latexmk -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=/data/out /data/src/secrist-resume
-latexmk -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=/data/out /data/src/secrist-cv
+latexmk -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=out secrist-resume
+latexmk -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=out secrist-cv

--- a/src/latexmkrc
+++ b/src/latexmkrc
@@ -1,2 +1,1 @@
 $ENV{'TZ'}='America/New_York';
-$ENV{'VERSION'}='v1.0.5';

--- a/src/secrist-coverletter.tex
+++ b/src/secrist-coverletter.tex
@@ -1,5 +1,5 @@
 % !TEX TS-program = latexmk
-% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=/data/out /data/src/secrist-coverletter
+% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=src/out src/secrist-coverletter
 
 \documentclass[localFont,alternative,compact]{yaac-another-awesome-cv}
 \selectlanguage{english}

--- a/src/secrist-cv.tex
+++ b/src/secrist-cv.tex
@@ -1,5 +1,5 @@
 % !TEX TS-program = latexmk
-% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=/data/out /data/src/secrist-cv
+% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=src/out src/secrist-cv
 
 \documentclass[localFont,alternative,compact]{yaac-another-awesome-cv}
 \selectlanguage{english}

--- a/src/secrist-resume.tex
+++ b/src/secrist-resume.tex
@@ -1,5 +1,5 @@
 % !TEX TS-program = latexmk
-% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=/data/out /data/src/secrist-resume
+% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=src/out src/secrist-resume
 
 \documentclass[localFont,alternative,compact]{yaac-another-awesome-cv}
 \selectlanguage{english}


### PR DESCRIPTION
1) Builds the Dockerfile and pushes to GHCR so it can be shared. One issue I've run into in the past is the Dockerfile becoming out-of-date and I'm unable to develop without fixing it. With an image pushed to the registry, at least there'll be a working image to start with.
2) Builds the docs in GHA so it can be previewed without actually needing to develop locally, for basic changes
3) Builds and automatically creates a release whenever there's a push to `main`, and automatically uploads the artifacts for the build to that release.